### PR TITLE
Minimal example where both series are violating invariants

### DIFF
--- a/nn-data-leak/Makefile
+++ b/nn-data-leak/Makefile
@@ -1,30 +1,40 @@
 VW = vw
 
-FIXED_VW_ARGS = --noconstant -k --learning_rate 2 --progress 1
+FIXED_VW_ARGS = --noconstant -k --learning_rate 10 --progress 1
 DATA = leaktest.vw
-NN = 2
+NN = 1
 VW_NNARGS = --nn $(NN)
 # Adding --multitask makes no difference (same bug)
 
-all: default isolated-nn nn-leak
+NS1=$(shell grep -Eo -- 'always[0-9]' $(DATA) | head -1)
+NS2=$(shell grep -Eo -- 'always[0-9]' $(DATA) | tail -1)
+
+all: check default isolated-nn nn-leak
+
+check:
+	# -- Name-spaces are:  1:$(NS1)  2:$(NS2)
 
 default:
 	#
 	# Verifying normal no --nn (thus no leak) operation
 	#
-	vw $(FIXED_VW_ARGS) -d $(DATA) 2>&1 | ./check-progress
+	vw $(FIXED_VW_ARGS) -d $(DATA) 2>&1 | \
+	    ./check-progress
 
 isolated-nn:
 	#
 	# Verifying isolated name-spaces with --nn
 	#
-	grep 'always2' $(DATA) | \
-	    vw $(FIXED_VW_ARGS) $(VW_NNARGS) -d /dev/stdin 2>&1 |./check-progress
-	grep 'always5' $(DATA) | \
-	    vw $(FIXED_VW_ARGS) $(VW_NNARGS) -d /dev/stdin 2>&1 |./check-progress
+	grep -- "$(NS1)" $(DATA) | \
+	    vw $(FIXED_VW_ARGS) $(VW_NNARGS) -d /dev/stdin 2>&1 | \
+	    	./check-progress
+	grep -- "$(NS2)" $(DATA) | \
+	    vw $(FIXED_VW_ARGS) $(VW_NNARGS) -d /dev/stdin 2>&1 | \
+	    	./check-progress
 
 nn-leak:
 	#
 	# Triggering bug (data leak between name-spaces with --nn)
 	#
-	vw $(FIXED_VW_ARGS) $(VW_NNARGS) -d $(DATA) 2>&1 | ./check-progress
+	vw $(FIXED_VW_ARGS) $(VW_NNARGS) -d $(DATA) 2>&1 | \
+	    ./check-progress

--- a/nn-data-leak/check-progress
+++ b/nn-data-leak/check-progress
@@ -6,8 +6,12 @@ next unless (/^\d/);
 my $actual = $F[4];
 my $predicted = $F[5];
 
-if ($actual == 5.0) { push(@P5, $predicted); }
-if ($actual == 2.0) { push(@P2, $predicted); }
+my $label = int($actual);
+
+my $array_name = "P$label";
+$ArrayNames{$array_name} = 1;
+
+push(@$array_name, $predicted);
 
 END {
     my $Errors = 0;
@@ -39,12 +43,14 @@ END {
             $prev_val = $val;
         }
     }
-    check_series(2.0, @P2);
-    check_series(5.0, @P5);
-
+    for my $arrname (keys %ArrayNames) {
+        my ($label) = ($arrname =~ /(\d+)/);
+        check_series($label, @$arrname);
+    }
     if ($Errors == 0) {
         print "All OK! (predicted values monotonically approaching label)";
-        print "\tP2: ", join(' ', @P2);
-        print "\tP5: ", join(' ', @P5);
+        for my $arrname (keys %ArrayNames) {
+            print "\t$arrname: ", join(' ', @$arrname);
+        }
     }
 }

--- a/nn-data-leak/leaktest.vw
+++ b/nn-data-leak/leaktest.vw
@@ -1,12 +1,10 @@
-5.0 time0/always5|always5  f1:1 f2:-1 f3:1 f4:-1
-2.0 time0/always2|always2  f1:1 f2:-1 f3:1 f4:-1
-5.0 time1/always5|always5  f1:1 f2:-1 f3:1 f4:-1
-2.0 time1/always2|always2  f1:1 f2:-1 f3:1 f4:-1
-5.0 time2/always5|always5  f1:1 f2:-1 f3:1 f4:-1
-2.0 time2/always2|always2  f1:1 f2:-1 f3:1 f4:-1
-5.0 time3/always5|always5  f1:1 f2:-1 f3:1 f4:-1
-2.0 time3/always2|always2  f1:1 f2:-1 f3:1 f4:-1
-5.0 time4/always5|always5  f1:1 f2:-1 f3:1 f4:-1
-2.0 time4/always2|always2  f1:1 f2:-1 f3:1 f4:-1
-5.0 time5/always5|always5  f1:1 f2:-1 f3:1 f4:-1
-2.0 time5/always2|always2  f1:1 f2:-1 f3:1 f4:-1
+6.0 time0/always6|always6  f1:1
+7.0 time0/always7|always7  f1:1
+6.0 time1/always6|always6  f1:1
+7.0 time1/always7|always7  f1:1
+6.0 time2/always6|always6  f1:1
+7.0 time2/always7|always7  f1:1
+6.0 time3/always6|always6  f1:1
+7.0 time3/always7|always7  f1:1
+6.0 time4/always6|always6  f1:1
+7.0 time4/always7|always7  f1:1


### PR DESCRIPTION
    Makefile:
        - use --nn 1, and higher --learning_rate
        - No hard-wiring of tags ('always<N>' arg to grep)

    check-progress:
        - Not hard-wiring any value
        - tags, labels & series names - all extracted from data

    leaktest.vw:
        - smaller data: less examples; only one feature
        - Simplify example as suggested by Alexey
          but leave the higher label intact, since we want to show the
          higher label set violating the invariants as well.

    README.md:
        - Add desired outcome
        - Add bug reference
        - update to latest data changes